### PR TITLE
transitions: allow external verifications for pending loan locations

### DIFF
--- a/invenio_circulation/config.py
+++ b/invenio_circulation/config.py
@@ -26,7 +26,7 @@ from .utils import can_be_requested, document_exists, document_ref_builder, \
     get_default_loan_duration, is_loan_duration_valid, item_can_circulate, \
     item_exists, item_location_retriever, item_ref_builder, patron_exists, \
     patron_ref_builder, transaction_location_validator, \
-    transaction_user_validator
+    transaction_user_validator, validate_item_pickup_transaction_locations
 
 CIRCULATION_ITEMS_RETRIEVER_FROM_DOCUMENT = None
 """Function that returns a list of item PIDs given a Document PID."""
@@ -125,6 +125,10 @@ CIRCULATION_TRANSACTION_LOCATION_VALIDATOR = transaction_location_validator
 
 CIRCULATION_TRANSACTION_USER_VALIDATOR = transaction_user_validator
 """Function that validates the User PID of the given transaction."""
+
+CIRCULATION_LOAN_LOCATIONS_VALIDATION = \
+    validate_item_pickup_transaction_locations
+"""Function that verifies pending loan item, pickup and transaction locs."""
 
 # JSON Schema resolvers
 CIRCULATION_ITEM_REF_BUILDER = item_ref_builder

--- a/invenio_circulation/utils.py
+++ b/invenio_circulation/utils.py
@@ -153,3 +153,18 @@ def transaction_user_validator(transaction_user_pid):
 def str2datetime(str_date):
     """Parse string date with timezone and return a datetime object."""
     return arrow.get(str_date).to('utc')
+
+
+def validate_item_pickup_transaction_locations(loan, destination, **kwargs):
+    """Validate the loan item, pickup and transaction locations.
+
+    This also allow for extra validation if needed at the library level.
+
+    :param loan: the loan
+    :param destination: the destination of the loan
+
+    :return: False if validation is not possible, otherwise True
+    """
+    raise NotImplementedConfigurationError(
+        config_variable="CIRCULATION_LOAN_LOCATIONS_VALIDATION"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ from .utils import can_be_requested, document_exists, document_ref_builder, \
     get_default_loan_duration, is_loan_duration_valid, item_can_circulate, \
     item_exists, item_location_retriever, item_ref_builder, patron_exists, \
     patron_ref_builder, transaction_location_validator, \
-    transaction_user_validator
+    transaction_user_validator, validate_item_pickup_transaction_locations
 
 
 @pytest.fixture(scope="module")
@@ -60,6 +60,8 @@ def app_config(app_config):
         transaction_location_validator
     app_config["CIRCULATION_TRANSACTION_USER_VALIDATOR"] = \
         transaction_user_validator
+    app_config["CIRCULATION_LOAN_LOCATIONS_VALIDATION"] = \
+        validate_item_pickup_transaction_locations
     app_config["CIRCULATION_DOCUMENT_RETRIEVER_FROM_ITEM"] = \
         lambda x: "document_pid"
     app_config["CIRCULATION_POLICIES"] = dict(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -89,3 +89,13 @@ def transaction_location_validator(transaction_location_pid):
 def transaction_user_validator(transaction_user_pid):
     """Validate that the given transaction user PID is valid."""
     return transaction_user_pid == "user_pid"
+
+
+def validate_item_pickup_transaction_locations(loan, destination, **kwargs):
+    """Validate the loan item, pickup and transaction locations."""
+    pickup_location_pid = loan["pickup_location_pid"]
+    item_location_pid = kwargs["item_location_pid"]
+    if destination == "ITEM_AT_DESK":
+        return pickup_location_pid == item_location_pid
+    elif destination == "ITEM_IN_TRANSIT_FOR_PICKUP":
+        return pickup_location_pid != item_location_pid


### PR DESCRIPTION
Adds a config CIRCULATION_LOAN_LOCATIONS_VERIFICATIONS to allow external
verifications of pending loan locations (item, pickup and transaction). or any extra customized validation.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>